### PR TITLE
feat: Modernize Email Template Editor UI to Match Gmail

### DIFF
--- a/frontend/src/components/TemplateEditor.jsx
+++ b/frontend/src/components/TemplateEditor.jsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { XMarkIcon, DocumentCheckIcon } from '@heroicons/react/24/outline';
+import { XMarkIcon, DocumentCheckIcon, EyeIcon, PencilIcon } from '@heroicons/react/24/outline';
 import { LexicalComposer } from '@lexical/react/LexicalComposer';
 import { RichTextPlugin } from '@lexical/react/LexicalRichTextPlugin';
 import { ContentEditable } from '@lexical/react/LexicalContentEditable';
@@ -88,9 +88,10 @@ const editorConfig = {
 function TemplateEditor({ initialTemplate, onSave, onClose }) {
   const [isSaving, setIsSaving] = useState(false);
   const [editorState, setEditorState] = useState();
-  const [htmlContent, setHtmlContent] = useState(initialTemplate?.body || '<p>Start editing your template here...</p>');
+  const [htmlContent, setHtmlContent] = useState(initialTemplate?.body || '<p>Start editing your professional email template here...</p>');
   const [templateName, setTemplateName] = useState(initialTemplate?.name || 'Custom Template');
   const [editorError, setEditorError] = useState(null);
+  const [isPreviewing, setIsPreviewing] = useState(false);
 
   // Handle saving the template
   const handleSave = () => {
@@ -124,57 +125,76 @@ function TemplateEditor({ initialTemplate, onSave, onClose }) {
         {/* Header */}
         <div className="flex items-center justify-between px-4 py-3 border-b border-gray-200">
           <h2 className="text-lg font-medium text-gray-800">Email Template Editor</h2>
-          <button
-            onClick={onClose}
-            className="text-gray-400 hover:text-gray-600"
-          >
-            <XMarkIcon className="h-5 w-5" />
-          </button>
+          <div className="flex items-center space-x-2">
+            <button
+              onClick={() => setIsPreviewing(!isPreviewing)}
+              className="p-1.5 rounded text-gray-500 hover:text-gray-700 hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-primary-500"
+              title={isPreviewing ? "Edit Template" : "Preview Template"}
+            >
+              {isPreviewing ? <PencilIcon className="h-5 w-5" /> : <EyeIcon className="h-5 w-5" />}
+            </button>
+            <button
+              onClick={onClose}
+              className="p-1.5 rounded text-gray-400 hover:text-gray-600 hover:bg-gray-100"
+              title="Close Editor"
+            >
+              <XMarkIcon className="h-5 w-5" />
+            </button>
+          </div>
         </div>
 
-        {/* Editor */}
+        {/* Editor or Preview Area */}
         <div className="p-4 flex-grow flex flex-col overflow-hidden">
-          <div className="mb-4">
-            <label htmlFor="templateName" className="block text-sm font-medium text-gray-700 mb-1">
-              Template Name
-            </label>
-            <input
-              type="text"
-              id="templateName"
-              value={templateName}
-              onChange={(e) => setTemplateName(e.target.value)}
-              className="block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-primary-500 focus:border-primary-500 sm:text-sm"
-            />
-          </div>
+          {!isPreviewing && (
+            <div className="mb-4">
+              <label htmlFor="templateName" className="block text-sm font-medium text-gray-700 mb-1">
+                Template Name
+              </label>
+              <input
+                type="text"
+                id="templateName"
+                value={templateName}
+                onChange={(e) => setTemplateName(e.target.value)}
+                className="block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-primary-500 focus:border-primary-500 sm:text-sm"
+              />
+            </div>
+          )}
 
           <div className="flex-grow flex flex-col overflow-hidden">
-            {editorError && (
+            {editorError && !isPreviewing && (
               <div className="bg-red-50 border border-red-200 text-red-700 px-4 py-2 rounded-md mb-2 text-sm">
                 <strong>Error:</strong> {editorError}
               </div>
             )}
 
-            {/* Lexical Editor */}
-            <LexicalComposer initialConfig={editorConfig}>
-              <div className="editor-container">
-                <ToolbarPlugin />
-                <div className="editor-inner">
-                  <RichTextPlugin
-                    contentEditable={<ContentEditable className="editor-input" />}
-                    placeholder={<div className="editor-placeholder">Start editing your professional email template here...</div>}
-                    ErrorBoundary={CustomErrorBoundary}
-                  />
-                  <OnChangePlugin onChange={handleEditorChange} />
-                  <HistoryPlugin />
-                  <AutoFocusPlugin />
-                  <ListPlugin />
-                  <LinkPlugin />
-                  <HorizontalRulePlugin />
-                  <MarkdownShortcutPlugin />
-                  <InitialContentPlugin />
-                </div>
+            {isPreviewing ? (
+              <div className="preview-area p-4 border border-gray-300 rounded-md bg-white h-full overflow-auto">
+                <div dangerouslySetInnerHTML={{ __html: htmlContent }} />
               </div>
-            </LexicalComposer>
+            ) : (
+              <LexicalComposer initialConfig={editorConfig}>
+                <div className="editor-container">
+                  {/* Editor content area */}
+                  <div className="editor-inner">
+                    <RichTextPlugin
+                      contentEditable={<ContentEditable className="editor-input" />}
+                      placeholder={<div className="editor-placeholder">Start editing your professional email template here...</div>}
+                      ErrorBoundary={CustomErrorBoundary}
+                    />
+                    <OnChangePlugin onChange={handleEditorChange} />
+                    <HistoryPlugin />
+                    <AutoFocusPlugin />
+                    <ListPlugin />
+                    <LinkPlugin />
+                    <HorizontalRulePlugin />
+                    <MarkdownShortcutPlugin />
+                    <InitialContentPlugin />
+                  </div>
+                  {/* Toolbar at the bottom */}
+                  <ToolbarPlugin />
+                </div>
+              </LexicalComposer>
+            )}
           </div>
         </div>
 
@@ -188,8 +208,9 @@ function TemplateEditor({ initialTemplate, onSave, onClose }) {
           </button>
           <button
             onClick={handleSave}
-            disabled={isSaving}
-            className="px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-primary-600 hover:bg-primary-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary-500 flex items-center"
+            disabled={isSaving || isPreviewing} // Disable save when previewing
+            className={`px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white flex items-center
+                        ${isPreviewing ? 'bg-gray-400 cursor-not-allowed' : 'bg-primary-600 hover:bg-primary-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary-500'}`}
           >
             {isSaving ? (
               <>

--- a/frontend/src/components/editor/InitialContentPlugin.jsx
+++ b/frontend/src/components/editor/InitialContentPlugin.jsx
@@ -11,7 +11,8 @@ export default function InitialContentPlugin() {
             const root = $getRoot();
             if (root.getChildrenSize() === 0) {
                 const paragraph = $createParagraphNode();
-                paragraph.append($createTextNode('Start editing your template here...'));
+                // Ensure consistency with the placeholder prop text
+                paragraph.append($createTextNode('Start editing your professional email template here...'));
                 root.append(paragraph);
             }
         });

--- a/frontend/src/components/editor/ToolbarPlugin.jsx
+++ b/frontend/src/components/editor/ToolbarPlugin.jsx
@@ -7,6 +7,8 @@ import {
     FORMAT_ELEMENT_COMMAND,
     UNDO_COMMAND,
     REDO_COMMAND,
+    INDENT_CONTENT_COMMAND,
+    OUTDENT_CONTENT_COMMAND,
 } from 'lexical';
 import {
     $createParagraphNode,
@@ -35,124 +37,114 @@ import {
 import { $createHorizontalRuleNode } from '@lexical/react/LexicalHorizontalRuleNode';
 import { INSERT_TABLE_COMMAND } from '@lexical/table';
 
-// Gmail-style SVG icons
+// Gmail-style SVG icons - All icons aim for viewBox="0 0 24 24" for consistency
+// Stroke width typically 1.8 or 2. Fill set to 'none' for outline icons.
 const Icons = {
     undo: (
-        <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-            <path d="M9 14 4 9l5-5" />
-            <path d="M4 9h10.5a5.5 5.5 0 0 1 5.5 5.5v0a5.5 5.5 0 0 1-5.5 5.5H11" />
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <path d="M2.5 7H12.5C17.1944 7 21 10.8056 21 15.5C21 20.1944 17.1944 24 12.5 24H11" transform="translate(0 -3.5)" />
+            <path d="M7 11.5L2.5 7L7 2.5" transform="translate(0 -3.5)" />
         </svg>
     ),
     redo: (
-        <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-            <path d="m15 14 5-5-5-5" />
-            <path d="M4 9h10.5A5.5 5.5 0 0 1 20 14.5v0a5.5 5.5 0 0 1-5.5 5.5H11" />
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <path d="M21.5 7H11.5C6.80558 7 3 10.8056 3 15.5C3 20.1944 6.80558 24 11.5 24H13" transform="translate(0 -3.5)" />
+            <path d="M17 11.5L21.5 7L17 2.5" transform="translate(0 -3.5)" />
         </svg>
     ),
     bold: (
-        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-            <path d="M6 4h8a4 4 0 0 1 4 4 4 4 0 0 1-4 4H6z" />
-            <path d="M6 12h9a4 4 0 0 1 4 4 4 4 0 0 1-4 4H6z" />
+        <svg viewBox="0 0 24 24" fill="currentColor" stroke="none">
+            <path d="M17.25 9.99999C17.25 11.2153 16.7754 12.3367 15.9789 13.1356C15.1824 13.9344 14.0642 14.4167 12.85 14.4167H8.33333V18.25H7V5.74999H12.85C14.0642 5.74999 15.1824 6.23228 15.9789 7.03117C16.7754 7.83005 17.25 8.95146 17.25 9.99999ZM10.0833 12.6667H12.85C13.5588 12.6667 14.1721 12.3226 14.6108 11.8826C15.0496 11.4426 15.4167 10.8279 15.4167 10C15.4167 9.1721 15.0496 8.55737 14.6108 8.11737C14.1721 7.67737 13.5588 7.5 12.85 7.5H10.0833V12.6667Z" />
         </svg>
     ),
     italic: (
-        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-            <line x1="19" y1="4" x2="10" y2="4" />
-            <line x1="14" y1="20" x2="5" y2="20" />
-            <line x1="15" y1="4" x2="9" y2="20" />
+        <svg viewBox="0 0 24 24" fill="currentColor" stroke="none">
+            <path d="M14.25 5.75L10.0833 5.75L10.0833 7.5L11.9021 7.5L9.20417 16.5L7.83333 16.5L7.83333 18.25L13.75 18.25L13.75 16.5L11.9292 16.5L14.6271 7.5L16 7.5L16 5.75L14.25 5.75Z" />
         </svg>
     ),
     underline: (
-        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-            <path d="M6 3v7a6 6 0 0 0 6 6 6 6 0 0 0 6-6V3" />
-            <line x1="4" y1="21" x2="20" y2="21" />
+        <svg viewBox="0 0 24 24" fill="currentColor" stroke="none">
+            <path d="M12 16.5C14.6019 16.5 16.5833 14.5159 16.5833 11.9062V5.75H14.8333V11.9062C14.8333 13.5771 13.5729 14.75 12 14.75C10.4271 14.75 9.16667 13.5771 9.16667 11.9062V5.75H7.41667V11.9062C7.41667 14.5159 9.39812 16.5 12 16.5ZM7 18.25H17V20H7V18.25Z" />
         </svg>
     ),
     strikethrough: (
-        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-            <path d="M16 4H9a3 3 0 0 0-2.83 4" />
-            <path d="M14 12a4 4 0 0 1 0 8H6" />
-            <line x1="4" y1="12" x2="20" y2="12" />
+        <svg viewBox="0 0 24 24" fill="currentColor" stroke="none">
+            <path d="M12.6641 13.5938C13.4271 13.349 13.9688 12.8333 14.2865 12.0469C14.6042 11.2604 14.7604 10.3802 14.75 9.40625C14.75 8.01042 14.3177 6.90625 13.4531 6.09375C12.5885 5.28125 11.4427 4.875 10.0156 4.875C8.93229 4.875 8.00521 5.08854 7.23438 5.51562C6.46354 5.94271 5.92708 6.55208 5.625 7.34375L7.20312 7.96875C7.39062 7.50521 7.70833 7.16146 8.15625 6.9375C8.60417 6.71354 9.21354 6.60417 9.98438 6.60417C10.8021 6.60417 11.4323 6.83333 11.875 7.29167C12.3177 7.75 12.5417 8.40625 12.5625 9.26042C12.5625 9.82292 12.4323 10.2917 12.1719 10.6667C11.9115 11.0417 11.5365 11.375 11.0469 11.6667L5.5 13.875V15.125H18.5V13.5938H12.6641Z M5.5 11.1875L9.3125 9.75C9.0026 9.0599 8.8474 8.34479 8.84375 7.60417C8.84375 7.27083 8.88021 6.97396 8.95312 6.71354L5.5 7.90625V11.1875Z" transform="translate(-0.5 0)" />
+             <path d="M4 12.5H20V11H4V12.5Z" />
         </svg>
     ),
     alignLeft: (
-        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-            <line x1="3" y1="6" x2="21" y2="6" />
-            <line x1="3" y1="12" x2="15" y2="12" />
-            <line x1="3" y1="18" x2="18" y2="18" />
+        <svg viewBox="0 0 24 24" fill="currentColor" stroke="none">
+            <path d="M3 6H21V7.5H3V6ZM3 11.25H15V12.75H3V11.25ZM3 16.5H21V18H3V16.5Z" />
         </svg>
     ),
     alignCenter: (
-        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-            <line x1="3" y1="6" x2="21" y2="6" />
-            <line x1="6" y1="12" x2="18" y2="12" />
-            <line x1="4" y1="18" x2="20" y2="18" />
+        <svg viewBox="0 0 24 24" fill="currentColor" stroke="none">
+            <path d="M3 6H21V7.5H3V6ZM5 11.25H19V12.75H5V11.25ZM3 16.5H21V18H3V16.5Z" />
         </svg>
     ),
     alignRight: (
-        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-            <line x1="3" y1="6" x2="21" y2="6" />
-            <line x1="9" y1="12" x2="21" y2="12" />
-            <line x1="6" y1="18" x2="21" y2="18" />
+        <svg viewBox="0 0 24 24" fill="currentColor" stroke="none">
+            <path d="M3 6H21V7.5H3V6ZM9 11.25H21V12.75H9V11.25ZM3 16.5H21V18H3V16.5Z" />
+        </svg>
+    ),
+     alignJustify: (
+        <svg viewBox="0 0 24 24" fill="currentColor" stroke="none">
+            <path d="M3 6H21V7.5H3V6ZM3 11.25H21V12.75H3V11.25ZM3 16.5H21V18H3V16.5Z" />
         </svg>
     ),
     bulletList: (
-        <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor" stroke="none">
-            <rect x="3" y="5" width="3" height="3" rx="1.5" />
-            <rect x="3" y="11" width="3" height="3" rx="1.5" />
-            <rect x="3" y="17" width="3" height="3" rx="1.5" />
-            <line x1="9" y1="6.5" x2="20" y2="6.5" stroke="currentColor" strokeWidth="1.5" />
-            <line x1="9" y1="12.5" x2="20" y2="12.5" stroke="currentColor" strokeWidth="1.5" />
-            <line x1="9" y1="18.5" x2="20" y2="18.5" stroke="currentColor" strokeWidth="1.5" />
+        <svg viewBox="0 0 24 24" fill="currentColor" stroke="none">
+            <path d="M7.83333 6H20V7.5H7.83333V6ZM7.83333 11.25H20V12.75H7.83333V11.25ZM7.83333 16.5H20V18H7.83333V16.5ZM4 6.75C4 7.30228 4.44772 7.75 5 7.75C5.55228 7.75 6 7.30228 6 6.75C6 6.19772 5.55228 5.75 5 5.75C4.44772 5.75 4 6.19772 4 6.75ZM4 12C4 12.5523 4.44772 13 5 13C5.55228 13 6 12.5523 6 12C6 11.4477 5.55228 11 5 11C4.44772 11 4 11.4477 4 12ZM4 17.25C4 17.8023 4.44772 18.25 5 18.25C5.55228 18.25 6 17.8023 6 17.25C6 16.6977 5.55228 16.25 5 16.25C4.44772 16.25 4 16.6977 4 17.25Z" />
         </svg>
     ),
     numberedList: (
-        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor">
-            <text x="3.5" y="7" fontSize="8" fontWeight="bold" fill="currentColor">1</text>
-            <text x="3.5" y="13" fontSize="8" fontWeight="bold" fill="currentColor">2</text>
-            <text x="3.5" y="19" fontSize="8" fontWeight="bold" fill="currentColor">3</text>
-            <line x1="9" y1="6.5" x2="20" y2="6.5" stroke="currentColor" strokeWidth="1.5" />
-            <line x1="9" y1="12.5" x2="20" y2="12.5" stroke="currentColor" strokeWidth="1.5" />
-            <line x1="9" y1="18.5" x2="20" y2="18.5" stroke="currentColor" strokeWidth="1.5" />
+        <svg viewBox="0 0 24 24" fill="currentColor" stroke="none">
+            <path d="M7.83333 6H20V7.5H7.83333V6ZM7.83333 11.25H20V12.75H7.83333V11.25ZM7.83333 16.5H20V18H7.83333V16.5ZM5.58333 5.75L4 5.75L4 10.0833L5.58333 10.0833V9L4.91667 9V8.08333L5.58333 8.08333V7.16667L4.91667 7.16667V6.66667L5.58333 6.66667V5.75ZM4.17391 11.1667L5.58333 12.5417L5.58333 13.8333L4.08333 13.8333L4.08333 13.125L3.125 13.125L3.125 12.125L4.08333 11.1667H4.17391ZM4.08333 12.2083L3.58333 12.625L3.58333 12.6667L4.08333 12.6667V12.2083ZM5.58333 15.5833C5.58333 16.1311 5.4251 16.5833 5.1087 16.9403C4.79229 17.2972 4.36389 17.5 3.82396 17.5C3.28403 17.5 2.84028 17.3125 2.5 16.9375C2.15972 16.5625 2.04167 16.0469 2.16667 15.3906L2.625 15.5833C2.5625 15.9583 2.66667 16.2708 2.9375 16.5226C3.20833 16.7743 3.5625 16.875 4 16.8333C4.27083 16.8333 4.49306 16.7396 4.66667 16.5521C4.84028 16.3646 4.91667 16.1042 4.89583 15.7604C4.89583 15.4583 4.79167 15.2083 4.58333 15.0104C4.375 14.8125 4.08333 14.6667 3.70833 14.5833L3.20833 14.4583L3.20833 14.9583L3.5 15.0417C3.79167 15.125 4 15.25 4.125 15.4167C4.25 15.5833 4.29167 15.75 4.25 15.9167H5.08333L5.08333 15.0833L5.58333 15.0833V15.5833Z" />
         </svg>
     ),
     link: (
-        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
             <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71" />
             <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71" />
         </svg>
     ),
-    horizontalRule: (
-        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-            <line x1="3" y1="12" x2="21" y2="12" />
+    horizontalRule: ( // This icon isn't standard in Gmail's formatting bar, but useful. Simple line.
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <line x1="4" y1="12" x2="20" y2="12" />
         </svg>
     ),
     quote: (
-        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-            <path d="M3 21c3 0 7-1 7-8V5c0-1.25-.756-2.017-2-2H4c-1.25 0-2 .75-2 1.972V11c0 1.25.75 2 2 2 1 0 1 0 1 1v1c0 1-1 2-2 2s-1 .008-1 1.031V20c0 1 0 1 1 1z" />
-            <path d="M15 21c3 0 7-1 7-8V5c0-1.25-.757-2.017-2-2h-4c-1.25 0-2 .75-2 1.972V11c0 1.25.75 2 2 2h.75c0 2.25.25 4-2.75 4v3c0 1 0 1 1 1z" />
+        <svg viewBox="0 0 24 24" fill="currentColor" stroke="none">
+            <path d="M8.41667 15.3333C9.52778 15.3333 10.4444 15.0139 11.1667 14.375C11.8889 13.7361 12.25 12.8889 12.25 11.8333V8.08333H10.0833L8.58333 11.1667H10.0833V11.8333C10.0833 12.4306 9.91088 12.8935 9.56616 13.2222C9.22143 13.5509 8.78333 13.7167 8.25183 13.7167C8.06806 13.7167 7.89097 13.6898 7.72083 13.6361L7.20833 15.0556C7.55556 15.2083 7.95139 15.3056 8.39583 15.3333H8.41667ZM15.0833 15.3333C16.1944 15.3333 17.1111 15.0139 17.8333 14.375C18.5556 13.7361 18.9167 12.8889 18.9167 11.8333V8.08333H16.75L15.25 11.1667H16.75V11.8333C16.75 12.4306 16.5776 12.8935 16.2329 13.2222C15.8881 13.5509 15.45 13.7167 14.9185 13.7167C14.7347 13.7167 14.5576 13.6898 14.3875 13.6361L13.875 15.0556C14.2222 15.2083 14.6181 15.3056 15.0625 15.3333H15.0833Z" />
         </svg>
     ),
-    clearFormatting: (
-        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-            <path d="M12 8V4H8" />
-            <rect x="4" y="4" width="16" height="16" rx="2" />
-            <path d="m16 16-3.37-3.37" />
-            <path d="m8 8 3.37 3.37" />
+    clearFormatting: ( // Icon for "Remove formatting" (Tx)
+        <svg viewBox="0 0 24 24" fill="currentColor" stroke="none">
+            <path d="M11.2778 15.3333L7.91667 6.75H9.63889L11.9028 12.4583L14.1667 6.75H15.8889L12.5278 15.3333H11.2778ZM15.3056 18.25L12.8056 12.9444L14.125 12.2917L17.1389 18.25H15.3056Z" />
+             <path d="M15.5 13.5 L18.5 16.5 M18.5 13.5 L15.5 16.5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round"/>
         </svg>
     ),
+    indentLess: (
+      <svg viewBox="0 0 24 24" fill="currentColor" stroke="none">
+        <path d="M3 6H21V7.5H3V6ZM3 11.25H21V12.75H3V11.25ZM3 16.5H21V18H3V16.5ZM9.5 9L6.5 12L9.5 15V9Z" />
+      </svg>
+    ),
+    indentMore: (
+      <svg viewBox="0 0 24 24" fill="currentColor" stroke="none">
+        <path d="M3 6H21V7.5H3V6ZM3 11.25H21V12.75H3V11.25ZM3 16.5H21V18H3V16.5ZM6.5 9L9.5 12L6.5 15V9Z" />
+      </svg>
+    )
 };
 
-// Gmail-style text format icon
+// Gmail-style text format icon (used for style/heading dropdown trigger)
 const TextFormatIcon = (
-    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-        <path d="M4 7V4h16v3" />
-        <path d="M9 20h6" />
-        <path d="M12 4v16" />
+    <svg viewBox="0 0 24 24" fill="currentColor" stroke="none" >
+        <path d="M9.41667 18.25L9.41667 7.58333L5.66667 7.58333L5.66667 5.75L18.1667 5.75L18.1667 7.58333L14.4167 7.58333L14.4167 18.25L12.5833 18.25L12.5833 12.5833L11.25 12.5833L11.25 18.25L9.41667 18.25Z"/>
     </svg>
 );
 
-// Font family options for the toolbar
+// Font family options for the toolbar - these are fine
 const FONT_FAMILY_OPTIONS = [
     { label: "Arial", value: "Arial, sans-serif" },
     { label: "Times New Roman", value: "'Times New Roman', Times, serif" },
@@ -211,6 +203,17 @@ export default function ToolbarPlugin() {
     const [isListActive, setIsListActive] = useState(false);
     const [listType, setListType] = useState(null); // 'bullet' or 'number'
     const [activeHeadingTag, setActiveHeadingTag] = useState("normal"); // 'normal', '1', '2', '3'
+
+
+    // INDENT HANDLERS
+    const handleIndent = () => {
+        editor.dispatchCommand(INDENT_CONTENT_COMMAND, undefined);
+    };
+
+    const handleOutdent = () => {
+        editor.dispatchCommand(OUTDENT_CONTENT_COMMAND, undefined);
+    };
+
 
     // Update format states based on selection
     useEffect(() => {
@@ -817,6 +820,12 @@ export default function ToolbarPlugin() {
                         title="Align Right">
                         <span className="format-icons">{Icons.alignRight}</span>
                     </button>
+                     <button
+                        onClick={handleAlignJustify}
+                        className={alignment === 'justify' ? "active" : ""}
+                        title="Align Justify">
+                        <span className="format-icons">{Icons.alignJustify}</span>
+                    </button>
 
                     <div className="divider"></div>
 
@@ -836,6 +845,16 @@ export default function ToolbarPlugin() {
                         data-active={isListActive && listType === 'bullet'}
                     >
                         <span className="format-icons">{Icons.bulletList}</span>
+                    </button>
+
+                    <div className="divider"></div>
+
+                    {/* Indent buttons */}
+                    <button onClick={handleOutdent} title="Indent Less">
+                        <span className="format-icons">{Icons.indentLess}</span>
+                    </button>
+                    <button onClick={handleIndent} title="Indent More">
+                        <span className="format-icons">{Icons.indentMore}</span>
                     </button>
 
                     <div className="divider"></div>

--- a/frontend/src/components/editor/editor.css
+++ b/frontend/src/components/editor/editor.css
@@ -1,257 +1,168 @@
+/* Base container for the entire editor component */
 .editor-container {
-    position: relative;
-    background: white;
-    border-radius: 8px;
+    position: relative; /* For positioning elements like placeholder or modals */
+    background: white; /* Background of the entire editor area */
+    border-radius: 8px; /* Rounded corners for the container */
     display: flex;
-    flex-direction: column;
-    height: 100%;
-    min-height: 300px;
-    box-shadow: 0 1px 2px 0 rgba(60, 64, 67, 0.3), 0 1px 3px 1px rgba(60, 64, 67, 0.15);
-    overflow: hidden;
+    flex-direction: column; /* Stack editor area and toolbar vertically */
+    height: 100%; /* Occupy full height of its parent in TemplateEditor.jsx */
+    min-height: 300px; /* Minimum height for usability */
+    box-shadow: 0 1px 2px 0 rgba(60, 64, 67, 0.3), 0 1px 3px 1px rgba(60, 64, 67, 0.15); /* Standard shadow */
+    overflow: hidden; /* Clip content like modals if they overflow */
 }
 
+/* Wrapper for the rich text input area */
 .editor-inner {
-    position: relative;
-    flex-grow: 1;
-    display: flex;
-    flex-direction: column;
-    background: white;
-    border-bottom-left-radius: 8px;
-    border-bottom-right-radius: 8px;
-    overflow: hidden;
+    position: relative; /* For absolute positioning of placeholder */
+    flex-grow: 1; /* Allow editor area to take up available space */
+    display: flex; /* Use flex for internal layout if needed */
+    flex-direction: column; /* Stack elements like ContentEditable */
+    background: white; /* Background of the text input area */
+    overflow: hidden; /* Hide scrollbars until needed */
+    border-top-left-radius: 8px; /* Match container rounding */
+    border-top-right-radius: 8px; /* Match container rounding */
 }
 
+/* The actual editable content area */
 .editor-input {
-    flex-grow: 1;
-    resize: none;
-    font-size: 14px;
-    caret-color: #202124;
+    flex-grow: 1; /* Expand to fill .editor-inner */
+    resize: none; /* Disable manual resizing by user */
+    font-size: 14px; /* Standard text size */
+    caret-color: #202124; /* Gmail's caret color */
     position: relative;
-    tab-size: 1;
-    outline: 0;
-    padding: 12px 16px;
-    overflow-y: auto;
-    height: 100%;
-    min-height: 240px;
-    border: 1px solid #dadce0;
-    border-top: none;
-    line-height: 1.5;
-    color: #202124;
-    font-family: Arial, sans-serif;
+    tab-size: 1; /* Define tab character width */
+    outline: 0; /* Remove default browser outline */
+    padding: 16px; /* Ample padding around text */
+    overflow-y: auto; /* Enable vertical scrolling when content exceeds height */
+    height: 100%; /* Fill available height */
+    min-height: 200px; /* Ensure a minimum usable editing area */
+    border-left: 1px solid #dadce0;
+    border-right: 1px solid #dadce0;
+    border-top: 1px solid #dadce0;
+    border-bottom: none; /* Toolbar is directly below */
+    line-height: 1.6; /* Improved readability */
+    color: #202124; /* Standard text color */
+    font-family: Arial, sans-serif; /* Default font */
+    border-top-left-radius: 7px; /* Align with container's border */
+    border-top-right-radius: 7px; /* Align with container's border */
+    border-bottom-left-radius: 0;
+    border-bottom-right-radius: 0;
 }
 
+/* Placeholder text style */
 .editor-placeholder {
-    color: #5f6368;
+    color: #757575; /* Gmail's placeholder color */
+    font-style: normal; /* Ensure placeholder is not italic */
     overflow: hidden;
     position: absolute;
     text-overflow: ellipsis;
-    top: 12px;
-    left: 16px;
-    -webkit-user-select: none;
-    -moz-user-select: none;
-    -ms-user-select: none;
+    top: 16px; /* Match editor-input padding */
+    left: 16px; /* Match editor-input padding */
     user-select: none;
     display: inline-block;
-    pointer-events: none;
-    font-style: italic;
-    font-size: 14px;
+    pointer-events: none; /* Allow clicks to pass through to the editor */
+    font-size: 14px; /* Match editor font size */
+    font-family: Arial, sans-serif; /* Match editor font */
 }
 
-.editor-text-bold {
-    font-weight: bold;
-}
-
-.editor-text-italic {
-    font-style: italic;
-}
-
-.editor-text-underline {
-    text-decoration: underline;
-}
-
-.editor-text-strikethrough {
-    text-decoration: line-through;
-}
-
-.editor-text-underlineStrikethrough {
-    text-decoration: underline line-through;
-}
+/* Text formatting styles */
+.editor-text-bold { font-weight: bold; }
+.editor-text-italic { font-style: italic; }
+.editor-text-underline { text-decoration: underline; }
+.editor-text-strikethrough { text-decoration: line-through; }
+.editor-text-underlineStrikethrough { text-decoration: underline line-through; }
 
 .editor-link {
-    color: rgb(33, 111, 219);
+    color: #1a73e8; /* Standard link color */
+    text-decoration: underline;
+}
+.editor-link:hover {
     text-decoration: none;
 }
 
 .editor-code {
-    background-color: rgb(240, 242, 245);
-    font-family: Menlo, Consolas, Monaco, monospace;
-    display: block;
-    padding: 8px 8px 8px 52px;
-    line-height: 1.53;
+    background-color: #f1f3f4; /* Light gray background for code blocks */
+    font-family: 'Roboto Mono', Menlo, Consolas, Monaco, monospace;
+    padding: 8px 12px;
     font-size: 13px;
-    margin: 0;
-    margin-top: 8px;
-    margin-bottom: 8px;
-    tab-size: 2;
-    white-space: pre;
+    line-height: 1.5;
+    margin: 8px 0;
+    border-radius: 4px;
+    white-space: pre-wrap; /* Wrap long lines of code */
     overflow-x: auto;
-    position: relative;
 }
 
 .editor-paragraph {
     margin: 0;
-    margin-bottom: 8px;
+    margin-bottom: 0.75em; /* Spacing between paragraphs */
     position: relative;
 }
-
-.editor-heading-h1 {
-    font-size: 24px;
-    font-weight: bold;
-    margin: 10px 0;
+.editor-paragraph:last-child {
+    margin-bottom: 0;
 }
 
-.editor-heading-h2 {
-    font-size: 20px;
-    font-weight: bold;
-    margin: 8px 0;
-}
-
-.editor-heading-h3 {
-    font-size: 16px;
-    font-weight: bold;
-    margin: 6px 0;
-}
+.editor-heading-h1 { font-size: 2em; font-weight: bold; margin: 0.67em 0; }
+.editor-heading-h2 { font-size: 1.5em; font-weight: bold; margin: 0.83em 0; }
+.editor-heading-h3 { font-size: 1.17em; font-weight: bold; margin: 1em 0; }
 
 .editor-horizontalrule {
     border: none;
-    border-top: 1px solid #e2e8f0;
-    margin: 1rem 0;
+    border-top: 1px solid #dadce0; /* Gmail-like divider */
+    margin: 1em 0;
     height: 1px;
 }
 
 .editor-quote {
-    margin: 0;
-    margin-left: 20px;
-    margin-bottom: 10px;
-    font-size: 15px;
-    color: rgb(101, 103, 107);
-    border-left-color: rgb(206, 208, 212);
-    border-left-width: 4px;
-    border-left-style: solid;
-    padding-left: 16px;
+    margin: 0 0 10px 0;
+    font-size: 1em;
+    color: #5f6368; /* Subtler quote text color */
+    border-left: 3px solid #dadce0; /* Gmail-style quote border */
+    padding-left: 12px;
 }
 
-.editor-list-ol {
-    list-style-type: decimal;
-    padding: 0;
-    margin: 0 0 0 16px;
+/* List Styles */
+.editor-list-ol, .editor-list-ul {
+    padding-left: 2em; /* Indentation for lists */
+    margin: 0.5em 0;
 }
-
-.editor-list-ul {
-    list-style-type: disc;
-    padding: 0;
-    margin: 0 0 0 16px;
-}
-
 .editor-listitem {
-    margin: 6px 0;
-    padding-left: 8px;
-    display: list-item;
+    margin: 0.25em 0;
+    padding-left: 0.25em;
+    display: list-item; /* Ensure correct list item rendering */
+}
+.editor-nested-listitem { /* For nested lists within list items */
+    list-style-type: none; /* Reset parent styling if needed */
 }
 
-.editor-nested-listitem {
-    list-style-type: none;
-    margin-left: 16px;
+/* Ensure correct display for lists inside editor-input */
+.editor-input ul, .editor-input ol {
+    padding-left: 2em;
+    margin: 0.5em 0;
 }
+.editor-input ul { list-style-type: disc; }
+.editor-input ol { list-style-type: decimal; }
+.editor-input li { margin-bottom: 0.25em; }
 
-/* Ensure nested lists appear correctly */
-.editor-list-ol li {
-    display: list-item;
-}
+/* Nested list styling for Gmail consistency */
+.editor-input ul ul, .editor-list-ul .editor-list-ul { list-style-type: circle; }
+.editor-input ul ul ul, .editor-list-ul .editor-list-ul .editor-list-ul { list-style-type: square; }
+.editor-input ol ol, .editor-list-ol .editor-list-ol { list-style-type: lower-alpha; }
+.editor-input ol ol ol, .editor-list-ol .editor-list-ol .editor-list-ol { list-style-type: lower-roman; }
 
-.editor-list-ul li {
-    display: list-item;
-}
 
-/* Add proper spacing for lists */
-.editor-list-ol ol,
-.editor-list-ul ul {
-    margin-top: 4px;
-    margin-bottom: 4px;
-}
-
-/* Add specific styles for different nesting levels */
-.editor-list-ul .editor-list-ul {
-    list-style-type: circle;
-}
-
-.editor-list-ul .editor-list-ul .editor-list-ul {
-    list-style-type: square;
-}
-
-.editor-list-ol .editor-list-ol {
-    list-style-type: lower-alpha;
-}
-
-.editor-list-ol .editor-list-ol .editor-list-ol {
-    list-style-type: lower-roman;
-}
-
-/* List styling */
-.editor-input ul,
-.editor-input ol {
-    padding-left: 24px;
-    margin: 8px 0;
-}
-
-.editor-input ul {
-    list-style-type: disc;
-}
-
-.editor-input ol {
-    list-style-type: decimal;
-}
-
-.editor-input li {
-    margin-bottom: 4px;
-}
-
-/* Nested lists */
-.editor-input ul ul,
-.editor-input ol ol,
-.editor-input ul ol,
-.editor-input ol ul {
-    margin-top: 4px;
-}
-
-.editor-input ul ul {
-    list-style-type: circle;
-}
-
-.editor-input ul ul ul {
-    list-style-type: square;
-}
-
-.editor-input ol ol {
-    list-style-type: lower-alpha;
-}
-
-.editor-input ol ol ol {
-    list-style-type: lower-roman;
-}
-
+/* Toolbar - now at the bottom */
 .toolbar {
-    background-color: #f2f2f2;
-    border-bottom: 1px solid #e0e0e0;
-    padding: 4px 8px;
+    background-color: #f5f5f5; /* Gmail's light gray toolbar background */
+    border-top: 1px solid #e0e0e0; /* Separator line above the toolbar */
+    padding: 5px 8px; /* Compact padding */
     display: flex;
-    flex-direction: row;
-    flex-wrap: nowrap;
-    align-items: center;
-    border-top-left-radius: 8px;
-    border-top-right-radius: 8px;
-    box-shadow: 0 1px 2px rgba(60, 64, 67, 0.1);
-    overflow-x: auto;
+    flex-direction: row; /* Main axis for toolbar items */
+    flex-wrap: nowrap; /* Prevent wrapping to multiple lines by default */
+    align-items: center; /* Vertically align items in the toolbar */
+    border-bottom-left-radius: 8px; /* Match container rounding */
+    border-bottom-right-radius: 8px; /* Match container rounding */
+    overflow-x: auto; /* Allow horizontal scrolling if items exceed width */
+    box-shadow: none; /* Remove previous top shadow */
 }
 
 .toolbar-row {
@@ -260,476 +171,458 @@
     flex-wrap: nowrap;
 }
 
-.toolbar-group {
+.toolbar-group { /* Optional: for grouping sets of buttons */
     display: inline-flex;
     align-items: center;
 }
 
+/* General styling for all toolbar buttons */
 .toolbar button {
     width: 28px;
     height: 28px;
-    min-width: 28px;
+    min-width: 28px; /* Prevent shrinking */
     display: flex;
     align-items: center;
     justify-content: center;
-    border-radius: 4px;
-    margin: 0 1px;
-    padding: 3px;
-    border: 1px solid transparent;
-    background: transparent;
+    border-radius: 3px; /* Slightly rounded corners, Gmail style */
+    margin: 0 1px; /* Minimal margin between buttons */
+    padding: 0; /* Icons should fill the button */
+    border: 1px solid transparent; /* No border by default, border appears on hover/focus for some elements */
+    background: transparent; /* No background by default */
     cursor: pointer;
-    position: relative;
-    color: #5f6368;
-    transition: background-color 0.2s, color 0.2s, border-color 0.2s;
+    color: #5f6368; /* Default icon color */
+    transition: background-color 0.15s ease-in-out, color 0.15s ease-in-out;
 }
 
-.toolbar-container button {
-    width: 28px;
-    height: 28px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    border-radius: 4px;
-    margin: 0 2px;
-    padding: 2px;
-    border: 1px solid transparent;
-    background: transparent;
-    cursor: pointer;
-    position: relative;
-}
-
-.toolbar-container button:hover {
-    background-color: rgba(60, 64, 67, 0.08);
-    border-color: transparent;
-}
-
-.toolbar-container button.active {
-    background-color: rgba(66, 133, 244, 0.1);
-    color: #4285f4;
-    border-color: rgba(66, 133, 244, 0.2);
-}
-
+/* Hover state for toolbar buttons */
 .toolbar button:hover {
-    background-color: #f0f0f0;
+    background-color: #efefef; /* Subtle gray on hover */
+    color: #3c4043; /* Slightly darker icon on hover */
 }
 
+/* Active (pressed or toggled) state for toolbar buttons */
 .toolbar button.active {
-    background-color: #e8f0fe;
-    color: #1a73e8;
+    background-color: #e4efff; /* Light blue for active state (e.g., Bold is on) */
+    color: #176dee; /* Blue icon color for active state */
+}
+.toolbar button:active { /* Momentary press style */
+    background-color: #dde6f2;
 }
 
-.toolbar button:active {
-    background-color: #e0e0e0;
-}
 
+/* Styling for select dropdowns (Font Family, Font Size, Heading) in the toolbar */
 .toolbar select {
-    padding: 2px 6px;
-    border: 1px solid #dadce0;
-    border-radius: 4px;
-    background-color: white;
-    font-size: 14px;
-    height: 28px;
-    margin: 0 2px;
+    height: 28px; /* Consistent height with buttons */
+    padding: 0 6px; /* Reduced horizontal padding */
+    padding-right: 22px; /* Space for custom arrow, slightly reduced */
+    font-size: 13px;
+    border: 1px solid transparent; /* No border in default state */
+    border-radius: 3px;
+    background-color: transparent; /* Fully transparent to blend with toolbar */
+    color: #3c4043; /* Dark gray text for readability */
+    margin: 0 1px; /* Minimal margin */
     cursor: pointer;
-    color: #444746;
-    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='%23444746' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='6 9 12 15 18 9'%3E%3C/polyline%3E%3C/svg%3E");
-    background-repeat: no-repeat;
-    background-position: right 6px center;
+    appearance: none;
     -webkit-appearance: none;
     -moz-appearance: none;
-    appearance: none;
-    padding-right: 20px;
+    background-image: url("data:image/svg+xml,%3Csvg width='16' height='16' viewBox='0 0 16 16' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M4.5 6L8 9.5L11.5 6' stroke='%235F6368' stroke-width='1.2' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E"); /* Slightly thinner arrow */
+    background-repeat: no-repeat;
+    background-position: right 5px center; /* Adjusted arrow position */
+    transition: border-color 0.1s ease-in-out, background-color 0.1s ease-in-out, box-shadow 0.1s ease-in-out;
+    line-height: 26px; /* Ensure text is vertically centered */
 }
 
 .toolbar select:hover {
-    border-color: #bdc1c6;
-    background-color: #f8f9fa;
+    background-color: #e0e0e0; /* Slightly darker hover than buttons for differentiation */
+    border-color: #c5c5c5; /* Subtle border on hover */
 }
 
-.toolbar select:focus {
-    border-color: #4285f4;
+.toolbar select:focus,
+.toolbar select:active { /* Style for when dropdown is open or focused */
+    border-color: #1a73e8;
+    background-color: #ffffff; /* White background when active/focused */
     outline: none;
+    box-shadow: 0 0 0 1px #1a73e8; /* Gmail-like focus ring */
 }
 
 .font-family-selector {
-    min-width: 110px;
-    max-width: 120px;
-    width: auto;
+    min-width: 90px;
+    max-width: 130px;
+    font-family: inherit; /* Use selected font for its own display if possible, or toolbar default */
 }
 
 .font-size-selector {
     min-width: 60px;
-    max-width: 70px;
-    width: auto;
+    max-width: 75px;
 }
 
-.heading-selector {
-    min-width: 120px;
-    max-width: 130px;
-    width: auto;
+/* Specific styling for the heading/text-style dropdown trigger */
+.text-style-dropdown { /* Container for icon + select */
+    position: relative;
+    display: flex;
+    align-items: center;
+    border-radius: 3px;
+    transition: background-color 0.1s ease-in-out, border-color 0.1s ease-in-out;
+    margin: 0 1px;
 }
 
+.text-style-dropdown:hover {
+    background-color: #e0e0e0;
+    border-color: #c5c5c5;
+}
+.text-style-dropdown .select-wrapper {
+    display: flex;
+    align-items: center;
+    position: relative;
+}
+
+.text-style-dropdown .dropdown-icon {
+    position: absolute;
+    left: 6px; /* Position icon nicely inside the dropdown */
+    top: 50%;
+    transform: translateY(-50%);
+    pointer-events: none;
+    color: #5f6368;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 1; /* Ensure icon is above select's background */
+}
+.text-style-dropdown .dropdown-icon svg {
+    width: 18px;
+    height: 18px;
+}
+
+.text-style-dropdown .heading-selector {
+    padding-left: 28px; /* Space for the icon */
+    min-width: 110px;
+    max-width: 140px;
+    border: 1px solid transparent; /* Match other selects */
+    background-color: transparent; /* Match other selects */
+}
+
+.text-style-dropdown:hover .heading-selector {
+    border-color: transparent; /* Hover on container, not select directly */
+}
+.text-style-dropdown .heading-selector:focus,
+.text-style-dropdown .heading-selector:active {
+    border-color: #1a73e8;
+    background-color: #ffffff;
+    box-shadow: 0 0 0 1px #1a73e8;
+}
+
+
+/* Color Picker Styles */
 .color-picker-container {
     position: relative;
     margin: 0 1px;
-    display: inline-flex;
+    display: inline-flex; /* Align button correctly */
 }
 
-.color-button {
+.color-button { /* Specific button for color picker trigger */
     padding: 0;
-    min-width: 28px !important;
-    width: 28px !important;
-    height: 28px !important;
+    width: 28px;
+    height: 28px;
     position: relative;
 }
 
-.color-button-inner {
-    width: 20px;
-    height: 20px;
-    border: 1px solid #ddd;
+.color-button-inner { /* Visual representation of the selected color */
+    width: 18px; /* Smaller than button for padding effect */
+    height: 18px;
+    border: 1px solid #bdbdbd; /* Border for the color swatch */
     border-radius: 2px;
+    display: flex; /* Center the 'A' or other content */
+    align-items: center;
+    justify-content: center;
+    font-size: 12px; /* For the 'A' in text color */
+    line-height: 1;
 }
 
-/* Gmail-style color grid dropdown */
+/* Dropdown for color palette */
 .color-grid-dropdown {
     position: absolute;
-    top: 100%;
-    left: 0;
+    bottom: 100%; /* Position above the toolbar */
+    left: 50%;
+    transform: translateX(-50%);
     background-color: white;
-    border: 1px solid #ddd;
+    border: 1px solid #d1d1d1; /* Gmail-like border */
     border-radius: 4px;
-    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.2);
+    box-shadow: 0 4px 8px rgba(0,0,0,0.15); /* Gmail-like shadow */
     z-index: 100;
-    margin-top: 4px;
-    width: 180px;
-    padding: 6px;
+    margin-bottom: 6px; /* Space from toolbar */
+    width: auto; /* Auto width based on content */
+    min-width: 180px; /* Minimum width */
+    padding: 8px;
+}
+.color-grid-dropdown .color-grid-header {
+    font-size: 12px;
+    color: #5f6368;
+    margin-bottom: 6px;
+    padding: 0 2px;
 }
 
-/* Proper color grid layout */
 .color-grid {
-    display: flex;
-    flex-direction: column;
-    gap: 2px;
-}
-
-.color-grid-row {
-    display: flex;
-    flex-direction: row;
-    gap: 2px;
+    display: grid;
+    grid-template-columns: repeat(10, 1fr); /* 10 colors per row, matching Gmail */
+    gap: 3px; /* Gap between color cells */
 }
 
 .color-grid-cell {
-    width: 14px;
-    height: 14px;
-    border-radius: 2px;
-    border: 1px solid rgba(0, 0, 0, 0.1);
+    width: 16px;
+    height: 16px;
+    border-radius: 50%; /* Circular color swatches */
+    border: 1px solid transparent;
     cursor: pointer;
-    padding: 0;
-    margin: 0;
+    transition: transform 0.1s ease-out, border-color 0.1s ease-out;
 }
-
 .color-grid-cell:hover {
     transform: scale(1.2);
-    z-index: 10;
-    box-shadow: 0 1px 3px rgba(60, 64, 67, 0.3);
+    border-color: #a0a0a0; /* Border on hover to highlight */
+    z-index: 1; /* Bring to front */
 }
-
-.transparent-cell {
+.color-grid-cell.transparent-cell { /* Special styling for transparent option */
     background-image: linear-gradient(45deg, #ccc 25%, transparent 25%, transparent 75%, #ccc 75%, #ccc),
-        linear-gradient(45deg, #ccc 25%, transparent 25%, transparent 75%, #ccc 75%, #ccc);
-    background-size: 6px 6px;
-    background-position: 0 0, 3px 3px;
-    background-color: white;
-    position: relative;
-    margin-bottom: 4px;
+                      linear-gradient(45deg, #ccc 25%, transparent 25%, transparent 75%, #ccc 75%, #ccc);
+    background-size: 8px 8px;
+    background-position: 0 0, 4px 4px;
+    border: 1px solid #ccc;
 }
-
-.transparent-indicator {
-    position: absolute;
-    top: 0;
-    left: 0;
+.transparent-indicator { /* For the slash icon on transparent */
+    display: flex;
+    align-items: center;
+    justify-content: center;
     width: 100%;
     height: 100%;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    font-size: 10px;
-    color: #444746;
+    font-size: 14px;
+    color: #5f6368;
 }
 
-.color-dropdown {
-    position: absolute;
-    top: 100%;
-    left: 0;
-    z-index: 1000;
-    background: white;
-    border: 1px solid #e2e8f0;
-    border-radius: 4px;
-    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
-    padding: 6px;
-    display: grid;
-    grid-template-columns: repeat(5, 1fr);
-    gap: 4px;
-    width: 150px;
-}
 
-.color-option {
-    width: 20px;
-    height: 20px;
-    border-radius: 3px;
-    border: 1px solid #e2e8f0;
-    cursor: pointer;
-}
-
-.color-option:hover {
-    transform: scale(1.1);
-}
-
+/* Link Modal */
 .link-modal {
-    position: fixed;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    background-color: rgba(60, 64, 67, 0.3);
+    position: fixed; /* Cover viewport */
+    top: 0; left: 0; right: 0; bottom: 0;
+    background-color: rgba(0,0,0,0.32); /* Standard overlay color */
     display: flex;
     align-items: center;
     justify-content: center;
-    z-index: 1000;
+    z-index: 1000; /* Above other content */
 }
-
 .link-modal-content {
     background-color: white;
-    padding: 16px 20px;
+    padding: 20px 24px;
     border-radius: 8px;
     width: 90%;
-    max-width: 400px;
-    box-shadow: 0 1px 3px 0 rgba(60, 64, 67, 0.3), 0 4px 8px 3px rgba(60, 64, 67, 0.15);
+    max-width: 420px; /* Max width for the modal */
+    box-shadow: 0 5px 15px rgba(0,0,0,0.2);
 }
-
 .link-modal-content h4 {
     margin-top: 0;
     margin-bottom: 16px;
     color: #202124;
     font-size: 16px;
-    font-weight: 500;
+    font-weight: 500; /* Medium weight for title */
 }
-
-.link-modal-content input {
+.link-modal-content input[type="text"] {
     width: 100%;
-    padding: 8px 12px;
+    padding: 10px 12px;
     margin-bottom: 16px;
     border: 1px solid #dadce0;
     border-radius: 4px;
     font-size: 14px;
+    box-sizing: border-box;
 }
-
-.link-modal-content input:focus {
+.link-modal-content input[type="text"]:focus {
     outline: none;
     border-color: #1a73e8;
-    box-shadow: 0 0 0 1px rgba(26, 115, 232, 0.2);
+    box-shadow: 0 0 0 1px #1a73e8 inset; /* Inner shadow for focus */
 }
-
 .link-modal-buttons {
     display: flex;
     justify-content: flex-end;
-    gap: 8px;
+    gap: 8px; /* Space between buttons */
 }
-
 .link-modal-buttons button {
     padding: 8px 16px;
-    border: none;
+    border: 1px solid transparent;
     border-radius: 4px;
     cursor: pointer;
     font-size: 14px;
     font-weight: 500;
+    transition: background-color 0.15s ease, border-color 0.15s ease;
 }
-
-.link-modal-buttons button:first-child {
-    background-color: transparent;
+.link-modal-buttons button:first-child { /* Cancel button */
     color: #1a73e8;
+    background-color: transparent;
 }
-
 .link-modal-buttons button:first-child:hover {
-    background-color: #f6fafe;
+    background-color: #f0f6ff; /* Light blue hover for cancel */
 }
-
-.link-modal-buttons button:last-child {
+.link-modal-buttons button:last-child { /* Save button */
     background-color: #1a73e8;
     color: white;
+    border-color: #1a73e8;
+}
+.link-modal-buttons button:last-child:hover {
+    background-color: #1668c7; /* Darker blue on hover */
+    border-color: #1668c7;
 }
 
+
+/* Divider between button groups in toolbar */
 .toolbar .divider {
     width: 1px;
-    height: 20px;
-    background-color: #dadce0;
-    margin: 0 4px;
+    height: 18px; /* Shorter than toolbar height */
+    background-color: #dadce0; /* Standard divider color */
+    margin: 0 6px; /* Spacing around divider */
     flex-shrink: 0;
 }
 
-.button-group {
-    display: inline-flex;
-    margin: 0 2px;
-}
-
+/* SVG Icons styling within buttons */
 .toolbar .format-icons {
     display: flex;
     align-items: center;
     justify-content: center;
-    line-height: 1;
-    height: 100%;
     width: 100%;
-    color: #444746;
+    height: 100%;
 }
-
 .toolbar .format-icons svg {
-    stroke: currentColor;
+    width: 18px; /* Adjust icon size as needed */
+    height: 18px;
+    fill: currentColor; /* Use button's color for fill if needed, else stroke */
+    stroke: currentColor; /* Default for outline icons */
+}
+.toolbar button.active .format-icons { /* Icon color change when button is active */
+    color: #176dee;
+}
+.toolbar button:hover .format-icons {
+    color: #3c4043;
+}
+/* Specific icon adjustments if needed */
+.toolbar button[title="Bold"] .format-icons svg,
+.toolbar button[title="Italic"] .format-icons svg {
+     /* Example: stroke-width: 2.2; if needed */
 }
 
-.toolbar button.active .format-icons svg {
-    stroke: #1a73e8;
-}
-
-.toolbar button:hover .format-icons svg {
-    stroke-width: 2.2;
-}
-
-/* Improve Gmail-like appearance for specific buttons */
-.toolbar button[title="Heading 1"] .format-icons,
-.toolbar button[title="Heading 2"] .format-icons,
-.toolbar button[title="Heading 3"] .format-icons {
-    font-weight: 600;
-    font-size: 14px;
-}
-
-.toolbar .font-family-selector,
-.toolbar .font-size-selector {
-    padding: 4px 8px;
-    border: 1px solid #dadce0;
-    border-radius: 4px;
-    font-size: 14px;
-    color: #444746;
+/* General styling for dropdown containers if using a div wrapper */
+.dropdown-container {
+    position: relative;
+    display: inline-flex; /* Align with other toolbar items */
+    align-items: center;
     height: 28px;
-    background-color: white;
+    margin: 0 1px;
 }
-
-.toolbar .font-family-selector:hover,
-.toolbar .font-size-selector:hover {
-    border-color: #c6c6c6;
-    background-color: #f8f8f8;
-}
-
-.toolbar .font-family-selector:focus,
-.toolbar .font-size-selector:focus {
-    outline: none;
-    border-color: #1a73e8;
-    box-shadow: 0 0 0 1px rgba(26, 115, 232, 0.2);
-}
-
-/* Active states for list buttons */
-.toolbar-container button[data-active="true"] {
-    background-color: rgba(66, 133, 244, 0.1);
-    color: #4285f4;
-    border-color: rgba(66, 133, 244, 0.2);
-}
-
-.toolbar-container button:active {
-    background-color: rgba(66, 133, 244, 0.2);
-}
-
-.editor-error-boundary {
-    background-color: #fee2e2;
-    color: #b91c1c;
-    padding: 1rem;
-    border: 1px solid #f87171;
-    border-radius: 0.25rem;
-    margin-bottom: 1rem;
-}
-
-.editor-error-boundary details {
-    margin-top: 0.5rem;
-    padding: 0.5rem;
-    background-color: rgba(255, 255, 255, 0.5);
-    border-radius: 0.25rem;
-}
-
-@media (max-width: 768px) {
-    .toolbar-row {
-        flex-wrap: wrap;
-    }
-}
-
-/* Gmail-style dropdowns */
-.toolbar select,
-.dropdown-container select {
-    height: 28px;
-    padding: 0 24px 0 8px;
-    font-size: 14px;
-    border: 1px solid #dadce0;
-    border-radius: 4px;
-    background-color: #fff;
-    color: #202124;
-    appearance: none;
-    background-image: url("data:image/svg+xml;charset=US-ASCII,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2212%22%20height%3D%2212%22%20viewBox%3D%220%200%2012%2012%22%3E%3Cpath%20fill%3D%22%23555%22%20d%3D%22M6%209L1%204h10z%22%2F%3E%3C%2Fsvg%3E");
-    background-repeat: no-repeat;
-    background-position: right 8px center;
-    cursor: pointer;
-    margin: 0 2px;
-    min-width: 80px;
-    max-width: 120px;
-}
-
-.toolbar select:hover,
-.dropdown-container select:hover {
-    border-color: #bdc1c6;
-    background-color: #f8f9fa;
-}
-
-.toolbar select:focus,
-.dropdown-container select:focus {
-    border-color: #4285f4;
-    outline: none;
-}
-
-/* Gmail-style text dropdown */
+/* Special handling for text style (heading) dropdown if it uses an icon + select */
 .text-style-dropdown .select-wrapper {
     position: relative;
     display: flex;
     align-items: center;
 }
-
-.text-style-dropdown .dropdown-icon {
+.text-style-dropdown .dropdown-icon { /* Icon placed before the select */
     position: absolute;
-    left: 8px;
-    pointer-events: none;
-    display: flex;
-    align-items: center;
+    left: 6px; /* Position icon inside the select-like appearance */
+    top: 50%;
+    transform: translateY(-50%);
+    pointer-events: none; /* Icon should not be interactive */
     color: #5f6368;
-    z-index: 1;
+    z-index: 1; /* Above the select background */
 }
-
 .text-style-dropdown .heading-selector {
-    padding-left: 30px;
-    background-color: #fff;
-    font-family: Arial, sans-serif;
+    padding-left: 28px; /* Make space for the icon */
+    min-width: 120px;
 }
 
-/* Better dropdown positioning */
-.dropdown-container {
-    position: relative;
-    display: inline-flex;
-    margin: 0 2px;
-    align-items: center;
-    height: 28px;
+
+/* Error Boundary Styling */
+.editor-error-boundary {
+    background-color: #fef2f2; /* Lighter red for background */
+    color: #991b1b; /* Darker red for text */
+    padding: 12px 16px;
+    border: 1px solid #fecaca; /* Light red border */
+    border-radius: 4px;
+    margin: 10px 0; /* Spacing if it appears */
+}
+.editor-error-boundary details {
+    margin-top: 8px;
+    padding: 8px;
+    background-color: rgba(255,255,255,0.6);
+    border-radius: 4px;
+    font-size: 0.9em;
+}
+.editor-error-boundary summary {
+    cursor: pointer;
+    font-weight: 500;
 }
 
-/* Match Gmail's native text style button */
-.text-style-dropdown {
-    margin-left: 3px;
+
+/* Responsive adjustments for smaller screens */
+@media (max-width: 768px) {
+    .toolbar-row {
+        flex-wrap: wrap; /* Allow toolbar items to wrap on small screens */
+        padding: 2px 0; /* Adjust padding if wrapping */
+    }
+    .toolbar .divider {
+        margin: 0 3px; /* Reduce margin for dividers on smaller screens */
+    }
+    .toolbar button, .toolbar select {
+        margin: 1px; /* Reduce margins for buttons/selects */
+    }
+    .color-grid-dropdown { /* Ensure dropdown doesn't go off-screen */
+        left: 10px;
+        transform: translateX(0);
+        max-width: calc(100vw - 20px);
+    }
 }
 
-/* Gmail-like toolbar spacing and layout */
-.toolbar-container {
-    flex-wrap: nowrap;
-    display: flex;
+/* Styling for the Preview Area */
+.preview-area {
+    background-color: #ffffff; /* White background like a typical email */
+    border: 1px solid #e0e0e0; /* Subtle border */
+    border-radius: 4px; /* Slightly rounded corners */
+    padding: 16px; /* Padding around the content */
+    height: 100%; /* Fill available space */
+    overflow-y: auto; /* Allow scrolling for long previews */
+    font-family: Arial, sans-serif; /* Default email font */
+    font-size: 14px; /* Default email font size */
+    line-height: 1.6; /* Email line height */
+    color: #202124; /* Default text color */
 }
+
+/* Ensure preview content uses the full width and doesn't have unexpected margins */
+.preview-area > div {
+    width: 100%;
+    margin: 0;
+}
+
+/* Basic styling for elements within the preview to mimic email client rendering */
+.preview-area h1, .preview-area h2, .preview-area h3, .preview-area h4, .preview-area h5, .preview-area h6 {
+    margin-top: 0.5em;
+    margin-bottom: 0.5em;
+}
+.preview-area p {
+    margin-top: 0;
+    margin-bottom: 1em;
+}
+.preview-area ul, .preview-area ol {
+    padding-left: 2em;
+    margin-bottom: 1em;
+}
+.preview-area li {
+    margin-bottom: 0.25em;
+}
+.preview-area a {
+    color: #1a73e8; /* Standard link color */
+    text-decoration: underline;
+}
+.preview-area blockquote {
+    border-left: 3px solid #ccc;
+    padding-left: 10px;
+    margin-left: 0;
+    color: #555;
+}
+.preview-area hr {
+    border: none;
+    border-top: 1px solid #ccc;
+    margin: 1em 0;
+}
+/* Add more styles as needed to better reflect common email client rendering */


### PR DESCRIPTION
Redesigns the email template editor UI to closely replicate Gmail's native editor interface.

Key changes include:
- Toolbar moved to the bottom, with updated styling (background, buttons, spacing) to match Gmail's appearance.
- Icons updated to be consistent with Gmail's modern, clean style. Added icons for indent/outdent and justify alignment.
- Dropdowns (font family, font size, text styles) simplified with minimal borders and improved hover/focus states.
- Editor area styling refined for cleaner integration with the bottom toolbar.
- Ensured placeholder text is "Start editing your professional email template here..." and not italic.
- Verified functional consistency of all formatting options and HTML serialization for saving.
- Added an optional "Preview" toggle to view the rendered HTML content.
- Ensured toolbar responsiveness for smaller screens.